### PR TITLE
[DXP-486] Ingestion Service ingress exposes only publications endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Every delivery service container gets the following environment variables:
    ```
    </p>
    </details>
-2. Prepare Apache Pulsar for StreamX installation (run it only for the first time installation):
+3. Prepare Apache Pulsar for StreamX installation (run it only for the first time installation):
 
    > NOTE: DO NOT CHANGE THIS COMMAND TO UPGRADE AS IT WILL CLEAR ALL RUNNING STEAMX PODS!
 
@@ -186,7 +186,7 @@ Every delivery service container gets the following environment variables:
    </p>
    </details>
 
-3. Install StreamX Mesh with Helm chart:
+4. Install StreamX Mesh with Helm chart:
    ```bash
    helm upgrade streamx ./chart -n streamx \
      --set "imagePullSecrets[0].name=streamx-gar-json-key" \
@@ -222,7 +222,7 @@ kubectl -n streamx rollout status deployment -l app.kubernetes.io/instance=strea
 Next, from the `examples/reference/e2e` run:
 ```bash
 export STREAMX_INGESTION_REST_AUTH_TOKEN=$(kubectl -n streamx run jwt-token-provider --rm --restart=Never -it -q --image=curlimages/curl -- curl -X 'POST' 'http://streamx-rest-ingestion/auth/token?upn=test')
-./mvnw clean verify
+./mvnw verify
 ```
 
 > Note: you need JDK 17 to run the tests.
@@ -231,7 +231,7 @@ export STREAMX_INGESTION_REST_AUTH_TOKEN=$(kubectl -n streamx run jwt-token-prov
 <summary>See how to validate reference flow manually with cURL</summary>
 <p>
 
-Fetch JWT token to authenticate with StreamX REST Ingrestion Service:
+Fetch JWT token to authenticate with StreamX REST Ingrestion Service (`/auth/token` endpoint is not exposed via ingress):
 ```bash
 export STREAMX_INGESTION_REST_AUTH_TOKEN=$(kubectl -n streamx run jwt-token-provider --rm --restart=Never -it -q --image=curlimages/curl -- curl -X 'POST' 'http://streamx-rest-ingestion/auth/token?upn=test')
 ```

--- a/chart/README.md.gotmpl
+++ b/chart/README.md.gotmpl
@@ -141,7 +141,7 @@ Every delivery service container gets the following environment variables:
    ```
    </p>
    </details>
-2. Prepare Apache Pulsar for StreamX installation (run it only for the first time installation):
+3. Prepare Apache Pulsar for StreamX installation (run it only for the first time installation):
 
    > NOTE: DO NOT CHANGE THIS COMMAND TO UPGRADE AS IT WILL CLEAR ALL RUNNING STEAMX PODS!
 
@@ -169,7 +169,7 @@ Every delivery service container gets the following environment variables:
    </p>
    </details>
 
-3. Install StreamX Mesh with Helm chart:
+4. Install StreamX Mesh with Helm chart:
    ```bash
    helm upgrade streamx ./chart -n streamx \
      --set "imagePullSecrets[0].name=streamx-gar-json-key" \
@@ -205,7 +205,7 @@ kubectl -n streamx rollout status deployment -l app.kubernetes.io/instance=strea
 Next, from the `examples/reference/e2e` run:
 ```bash
 export STREAMX_INGESTION_REST_AUTH_TOKEN=$(kubectl -n streamx run jwt-token-provider --rm --restart=Never -it -q --image=curlimages/curl -- curl -X 'POST' 'http://streamx-rest-ingestion/auth/token?upn=test')
-./mvnw clean verify
+./mvnw verify
 ```
 
 > Note: you need JDK 17 to run the tests.
@@ -214,7 +214,7 @@ export STREAMX_INGESTION_REST_AUTH_TOKEN=$(kubectl -n streamx run jwt-token-prov
 <summary>See how to validate reference flow manually with cURL</summary>
 <p>
 
-Fetch JWT token to authenticate with StreamX REST Ingrestion Service:
+Fetch JWT token to authenticate with StreamX REST Ingrestion Service (`/auth/token` endpoint is not exposed via ingress):
 ```bash
 export STREAMX_INGESTION_REST_AUTH_TOKEN=$(kubectl -n streamx run jwt-token-provider --rm --restart=Never -it -q --image=curlimages/curl -- curl -X 'POST' 'http://streamx-rest-ingestion/auth/token?upn=test')
 ```

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -28,7 +28,7 @@ Deploy StreamX Mesh when the initialization completes successfully.
 
 {{- with (.Values.rest_ingestion).ingress }}
 Ingestion services:
-- http{{ if (.tls).secretName }}s{{ end }}://{{ .host }}/q/swagger-ui
+- http{{ if (.tls).secretName }}s{{ end }}://{{ .host }}
 {{- end }}
 
 {{- if gt (len .Values.delivery) 0 }}

--- a/chart/templates/rest-ingestion-service/rest-ingestion-ingress.yaml
+++ b/chart/templates/rest-ingestion-service/rest-ingestion-ingress.yaml
@@ -37,7 +37,7 @@ spec:
     http:
       paths:
       - pathType: Prefix
-        path: "/"
+        path: "/publications"
         backend:
           service:
             name: {{ include "streamx.component.fullname" (dict "componentName" "rest-ingestion" "context" $) }}

--- a/chart/tests/unit/__snapshot__/notes_test.yaml.snap
+++ b/chart/tests/unit/__snapshot__/notes_test.yaml.snap
@@ -85,7 +85,7 @@ when rest_ingestion service ingress host is set then it is printed in notes with
       Happy StreamX Helming!
       ---------------------
       Ingestion services:
-      - http://rest.ingestion.host/q/swagger-ui
+      - http://rest.ingestion.host
 when rest_ingestion service ingress tls is set then it is printed in notes with https:
   1: |
     raw: |-
@@ -106,4 +106,4 @@ when rest_ingestion service ingress tls is set then it is printed in notes with 
       Happy StreamX Helming!
       ---------------------
       Ingestion services:
-      - https://rest.ingestion.host/q/swagger-ui
+      - https://rest.ingestion.host

--- a/chart/tests/unit/rest_ingestion_service_ingress_test.yaml
+++ b/chart/tests/unit/rest_ingestion_service_ingress_test.yaml
@@ -24,7 +24,7 @@ tests:
       - hasDocuments:
           count: 0
   # @Test
-  - it: when ingress host is set then ingress should be created
+  - it: when ingress host is set then ingress should be created and allow only "/publications" path
     set:
       rest_ingestion:
         ingress:
@@ -37,6 +37,9 @@ tests:
       - matchRegex:
           path: spec.rules[0].host
           pattern: unit.test.host
+      - matchRegex:
+          path: spec.rules[0].http.paths[0].path
+          pattern: /publications
   # @Test
   - it: when ingress tls secret is set then ingress should be created with tls settings
     set:

--- a/examples/reference/e2e/src/main/java/dev/streamx/chart/validation/StreamXEnvironment.java
+++ b/examples/reference/e2e/src/main/java/dev/streamx/chart/validation/StreamXEnvironment.java
@@ -46,12 +46,17 @@ public class StreamXEnvironment {
       return eventTime;
     }
   }
+
   public RequestSpecification newIngestionSchemaRequest() {
-    return given()
-        .baseUri(REST_INGESTION_HOST + PUBLICATIONS_API_BASE_PATH)
-        .basePath("/schema")
+    return newIngestionRequest(PUBLICATIONS_API_BASE_PATH + "/schema")
         .header("Authorization", "Bearer " + getAuthToken())
         .contentType(ContentType.JSON);
+  }
+
+  public RequestSpecification newIngestionRequest(String basePath) {
+    return given()
+        .baseUri(REST_INGESTION_HOST)
+        .basePath(basePath);
   }
 
   public RequestSpecification newDeliveryPageRequest(String pagePath) {

--- a/examples/reference/e2e/src/test/java/dev/streamx/chart/validation/ReferenceFlowTest.java
+++ b/examples/reference/e2e/src/test/java/dev/streamx/chart/validation/ReferenceFlowTest.java
@@ -72,4 +72,14 @@ public class ReferenceFlowTest {
     assertPageWithContent(environment.newDeliveryPageRequest(key), REFERENCE_PAGE_CONTENT);
   }
 
+  @Test
+  void makeSureAuthEndpointIsNotExposedPublicly(StreamXEnvironment environment)
+      throws StreamxClientException {
+    environment.newIngestionRequest("/auth/token?upn=test")
+        .post()
+        .then()
+        .assertThat()
+        .statusCode(404);
+  }
+
 }


### PR DESCRIPTION
Additionally fixing chart's NOTES.txt as the `/q/swagger-ui` endpoint is no longer available.