### PR TITLE
[DXP-623] add support for global envs for StreamX services

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ See the `templates/_helpers.tpl` helper functions to see the implementation deta
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | delivery | object | `{}` | `Delivery Services` map |
+| global.env | list | `[]` | global environment variables for all services, can be overridden by service specific env |
 | imagePullSecrets | list | `[]` | imagePullSecrets used to authenticate to registry containing StreamX and custom services |
 | messaging | object | `{}` | used to configure messaging system like Apache Pulsar, see examples for reference |
 | monitoring.enabled | bool | `false` | enabling this flag will enable creating `monitoring.coreos.com` Custom Resources for all services |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See the `templates/_helpers.tpl` helper functions to see the implementation deta
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | delivery | object | `{}` | `Delivery Services` map |
-| global.env | list | `[]` | global environment variables for all services, can be overridden by service specific env |
+| global.env | list | `[]` | global environment variables for all containers, can be overridden by component specific env |
 | imagePullSecrets | list | `[]` | imagePullSecrets used to authenticate to registry containing StreamX and custom services |
 | messaging | object | `{}` | used to configure messaging system like Apache Pulsar, see examples for reference |
 | monitoring.enabled | bool | `false` | enabling this flag will enable creating `monitoring.coreos.com` Custom Resources for all services |

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -194,23 +194,23 @@ startupProbe:
 {{- end }}
 
 {{/*
-Returns YAML list of environment variables with base environment variables and additional environment variables concatenated.
-The base envs entries have precedence over the additional entries (distinguished by the 'name').
+Returns YAML list of environment variables. It merges two lists of envs (name->value) giving precedence from overwrite to base, 
+effectively overwriting values in the base (distinguished by the 'name').
 Usage:
-{{ include "streamx.uniqEnvs" (dict "baseEnvs" <envs-list> "extraEnvs" <envs-list>) }}
+{{ include "streamx.mergeEnvs" (dict "baseEnvs" <envs-list> "overwriteEnvs" <envs-list>) }}
 */}}
-{{- define "streamx.uniqEnvs" -}}
+{{- define "streamx.mergeEnvs" -}}
+{{- $overwriteEnvs := .overwriteEnvs | default list }}
 {{- $baseEnvs := .baseEnvs | default list }}
-{{- $extraEnvs := .extraEnvs | default list }}
+{{- $overwriteDict := dict }}
+{{- range $overwriteEnvs }}
+{{- $_ := set $overwriteDict .name .value }}
+{{- end }}
 {{- $baseDict := dict }}
 {{- range $baseEnvs }}
 {{- $_ := set $baseDict .name .value }}
 {{- end }}
-{{- $extraDict := dict }}
-{{- range $extraEnvs }}
-{{- $_ := set $extraDict .name .value }}
-{{- end }}
-{{- $merged := mergeOverwrite $extraDict $baseDict -}}
+{{- $merged := mergeOverwrite $baseDict $overwriteDict -}}
 {{- range $key, $value := $merged }}
 - name: {{ $key }}
   value: {{ $value }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -192,3 +192,27 @@ startupProbe:
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns YAML list of environment variables with base environment variables and additional environment variables concatenated.
+The base envs entries have precedence over the additional entries (distinguished by the 'name').
+Usage:
+{{ include "streamx.uniqEnvs" (dict "baseEnvs" <envs-list> "extraEnvs" <envs-list>) }}
+*/}}
+{{- define "streamx.uniqEnvs" -}}
+{{- $baseEnvs := .baseEnvs | default list }}
+{{- $extraEnvs := .extraEnvs | default list }}
+{{- $baseDict := dict }}
+{{- range $baseEnvs }}
+{{- $_ := set $baseDict .name .value }}
+{{- end }}
+{{- $extraDict := dict }}
+{{- range $extraEnvs }}
+{{- $_ := set $extraDict .name .value }}
+{{- end }}
+{{- $merged := mergeOverwrite $extraDict $baseDict -}}
+{{- range $key, $value := $merged }}
+- name: {{ $key }}
+  value: {{ $value }}
+{{- end }}
+{{- end }}

--- a/chart/templates/delivery/delivery-deployment.yaml
+++ b/chart/templates/delivery/delivery-deployment.yaml
@@ -97,7 +97,7 @@ spec:
             {{- end }}
           {{- end }}
           env:
-            {{- include "streamx.uniqEnvs" (dict "baseEnvs" $container.env "extraEnvs" $.Values.global.env) | nindent 12 }}
+            {{- include "streamx.mergeEnvs" (dict "baseEnvs" $.Values.global.env "overwriteEnvs" $container.env) | nindent 12 }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/chart/templates/delivery/delivery-deployment.yaml
+++ b/chart/templates/delivery/delivery-deployment.yaml
@@ -97,6 +97,7 @@ spec:
             {{- end }}
           {{- end }}
           env:
+            {{- include "streamx.uniqEnvs" (dict "baseEnvs" $container.env "extraEnvs" $.Values.global.env) | nindent 12 }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -122,9 +123,6 @@ spec:
             - name: REPOSITORY_METADATA_ROOT_DIRECTORY # FixMe: to be checked if this is needed in StreamX
               value: {{ .metadataMountPath }}
             {{- end }}
-            {{- end }}
-            {{- if $container.env }}
-{{ toYaml $container.env | indent 12 }}
             {{- end }}
           volumeMounts:
             {{- with $container.data }}

--- a/chart/templates/messaging/pulsar-init-tenant-job.yaml
+++ b/chart/templates/messaging/pulsar-init-tenant-job.yaml
@@ -32,6 +32,7 @@ spec:
         - name: pulsar-init
           image: {{ (.initTenant).customImage | default (printf "ghcr.io/streamx-dev/streamx/pulsar-init:%s" $.Chart.AppVersion) }}
           env:
+            {{- include "streamx.uniqEnvs" (dict "baseEnvs" (.initTenant).env "extraEnvs" $.Values.global.env) | nindent 12 }}
             - name: STREAMX_TENANT
               value: {{ include "streamx.tenant" $ }}
             {{- include "streamx.pulsarEnvs" $ | nindent 12 }}
@@ -43,5 +44,7 @@ spec:
           args:
           - >
             until [[ $(curl -s -o /dev/null -w "%{http_code}" {{ .webServiceUrl }}/admin/v2/clusters) == "200" ]]; do echo "waiting for pulsar api"; sleep 5; done;
+          env:
+            {{- include "streamx.uniqEnvs" (dict "baseEnvs" (.initTenant).env "extraEnvs" $.Values.global.env) | nindent 12 }}
 {{- end }}
 {{- end }}

--- a/chart/templates/messaging/pulsar-init-tenant-job.yaml
+++ b/chart/templates/messaging/pulsar-init-tenant-job.yaml
@@ -32,7 +32,7 @@ spec:
         - name: pulsar-init
           image: {{ (.initTenant).customImage | default (printf "ghcr.io/streamx-dev/streamx/pulsar-init:%s" $.Chart.AppVersion) }}
           env:
-            {{- include "streamx.uniqEnvs" (dict "baseEnvs" (.initTenant).env "extraEnvs" $.Values.global.env) | nindent 12 }}
+            {{- include "streamx.mergeEnvs" (dict "baseEnvs" $.Values.global.env "overwriteEnvs" (.initTenant).env) | nindent 12 }}
             - name: STREAMX_TENANT
               value: {{ include "streamx.tenant" $ }}
             {{- include "streamx.pulsarEnvs" $ | nindent 12 }}
@@ -45,6 +45,6 @@ spec:
           - >
             until [[ $(curl -s -o /dev/null -w "%{http_code}" {{ .webServiceUrl }}/admin/v2/clusters) == "200" ]]; do echo "waiting for pulsar api"; sleep 5; done;
           env:
-            {{- include "streamx.uniqEnvs" (dict "baseEnvs" (.initTenant).env "extraEnvs" $.Values.global.env) | nindent 12 }}
+            {{- include "streamx.mergeEnvs" (dict "baseEnvs" $.Values.global.env "overwriteEnvs" (.initTenant).env) | nindent 12 }}
 {{- end }}
 {{- end }}

--- a/chart/templates/processing/processing-deployment.yaml
+++ b/chart/templates/processing/processing-deployment.yaml
@@ -60,6 +60,7 @@ spec:
             {{- end }}
           {{- end }}
           env:
+            {{- include "streamx.uniqEnvs" (dict "baseEnvs" $processing.env "extraEnvs" $.Values.global.env) | nindent 12 }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -79,9 +80,6 @@ spec:
               value: {{ include "streamx.channelTopic" (dict "channel" $channel "context" $) }}
             - name: MP_MESSAGING_OUTGOING_{{ $key | upper }}_PRODUCERNAME
               value: "$(POD_NAME)-{{ $key }}"
-            {{- end }}
-            {{- if $processing.env }}
-{{ toYaml $processing.env | indent 12 }}
             {{- end }}
           resources:
           {{- if $processing.resources }}          

--- a/chart/templates/processing/processing-deployment.yaml
+++ b/chart/templates/processing/processing-deployment.yaml
@@ -60,7 +60,7 @@ spec:
             {{- end }}
           {{- end }}
           env:
-            {{- include "streamx.uniqEnvs" (dict "baseEnvs" $processing.env "extraEnvs" $.Values.global.env) | nindent 12 }}
+            {{- include "streamx.mergeEnvs" (dict "baseEnvs" $.Values.global.env "overwriteEnvs" $processing.env) | nindent 12 }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/chart/templates/rest-ingestion-service/rest-ingestion-deployment.yaml
+++ b/chart/templates/rest-ingestion-service/rest-ingestion-deployment.yaml
@@ -49,6 +49,7 @@ spec:
             - name: http
               containerPort: 8080
           env:
+            {{- include "streamx.uniqEnvs" (dict "baseEnvs" .Values.rest_ingestion.env "extraEnvs" $.Values.global.env) | nindent 12 }}
             - name: STREAMX_TENANT
               value: {{ include "streamx.tenant" $ }}
             {{- include "streamx.pulsarEnvs" $ | nindent 12 }}
@@ -68,9 +69,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            {{- if .Values.rest_ingestion.env }}
-{{ toYaml .Values.rest_ingestion.env | indent 12 }}
-            {{- end }}
           volumeMounts:
             - name: jwt-keys
               mountPath: /etc/secrets/streamx

--- a/chart/templates/rest-ingestion-service/rest-ingestion-deployment.yaml
+++ b/chart/templates/rest-ingestion-service/rest-ingestion-deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - name: http
               containerPort: 8080
           env:
-            {{- include "streamx.uniqEnvs" (dict "baseEnvs" .Values.rest_ingestion.env "extraEnvs" $.Values.global.env) | nindent 12 }}
+            {{- include "streamx.mergeEnvs" (dict "baseEnvs" $.Values.global.env "overwriteEnvs" .Values.rest_ingestion.env) | nindent 12 }}
             - name: STREAMX_TENANT
               value: {{ include "streamx.tenant" $ }}
             {{- include "streamx.pulsarEnvs" $ | nindent 12 }}

--- a/chart/tests/unit/global_env_test.yaml
+++ b/chart/tests/unit/global_env_test.yaml
@@ -14,14 +14,15 @@
 
 # yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
 
-suite: test services global env vars
+suite: test chart components global env vars
 tests:
   # @Test
-  - it: when global env is set, then it is present in each service's container env
+  - it: when global env is set, then it is present in each service's container and init job
     templates:
       - templates/rest-ingestion-service/rest-ingestion-deployment.yaml
       - templates/processing/processing-deployment.yaml
       - templates/delivery/delivery-deployment.yaml
+      - templates/messaging/pulsar-init-tenant-job.yaml
     set:
       global:
         env:
@@ -29,8 +30,6 @@ tests:
             value: global-env-value
       messaging:
         pulsar:
-          serviceUrl: "pulsar://pulsar-service:6650"
-          webServiceUrl: "http://pulsar-web-service:8080"
           initTenant:
             enabled: true
       processing:
@@ -119,6 +118,60 @@ tests:
             value: delivery-env-value
       - notContains:
           path: spec.template.spec.containers[0].env
+          content:
+            name: GLOBAL_ENV
+            value: global-env-value
+  # @Test
+  - it: when global env is set the it is set in init tenant init container
+    template: templates/messaging/pulsar-init-tenant-job.yaml
+    set:
+      global:
+        env:
+          - name: GLOBAL_ENV
+            value: global-env-value
+      messaging:
+        pulsar:
+          initTenant:
+            enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: GLOBAL_ENV
+            value: global-env-value
+  # @Test
+  - it: when global env is set the it can be overwritten by init tenant job
+    template: templates/messaging/pulsar-init-tenant-job.yaml
+    set:
+      global:
+        env:
+          - name: GLOBAL_ENV
+            value: global-env-value
+      messaging:
+        pulsar:
+          initTenant:
+            enabled: true
+            env:
+              - name: GLOBAL_ENV
+                value: init-tenant-env-value
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLOBAL_ENV
+            value: init-tenant-env-value
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLOBAL_ENV
+            value: global-env-value
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: GLOBAL_ENV
+            value: init-tenant-env-value
+      - notContains:
+          path: spec.template.spec.initContainers[0].env
           content:
             name: GLOBAL_ENV
             value: global-env-value

--- a/chart/tests/unit/services_global_env_test.yaml
+++ b/chart/tests/unit/services_global_env_test.yaml
@@ -1,0 +1,124 @@
+# Copyright 2024 Dynamic Solutions Sp. z o.o. sp.k.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+
+suite: test services global env vars
+tests:
+  # @Test
+  - it: when global env is set, then it is present in each service's container env
+    templates:
+      - templates/rest-ingestion-service/rest-ingestion-deployment.yaml
+      - templates/processing/processing-deployment.yaml
+      - templates/delivery/delivery-deployment.yaml
+    set:
+      global:
+        env:
+          - name: GLOBAL_ENV
+            value: global-env-value
+      messaging:
+        pulsar:
+          serviceUrl: "pulsar://pulsar-service:6650"
+          webServiceUrl: "http://pulsar-web-service:8080"
+          initTenant:
+            enabled: true
+      processing:
+        service1:
+          image:
+            repository: test/processing-service
+      delivery:
+        service2:
+          containers:
+            test:
+              image:
+                repository: test/delivery-service
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLOBAL_ENV
+            value: global-env-value
+  # @Test
+  - it: when global env is set the it can be overwritten by rest ingestion service
+    template: templates/rest-ingestion-service/rest-ingestion-deployment.yaml
+    set:
+      global:
+        env:
+          - name: GLOBAL_ENV
+            value: global-env-value
+      rest_ingestion:
+        env:
+          - name: GLOBAL_ENV
+            value: rest-ingestion-env-value
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLOBAL_ENV
+            value: rest-ingestion-env-value
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLOBAL_ENV
+            value: global-env-value
+  # @Test
+  - it: when global env is set the it can be overwritten by processing services
+    template: templates/processing/processing-deployment.yaml
+    set:
+      global:
+        env:
+          - name: GLOBAL_ENV
+            value: global-env-value
+      processing:
+        service1:
+          env:
+            - name: GLOBAL_ENV
+              value: processing-env-value
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLOBAL_ENV
+            value: processing-env-value
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLOBAL_ENV
+            value: global-env-value
+  # @Test
+  - it: when global env is set the it can be overwritten by each delivery service container
+    template: templates/delivery/delivery-deployment.yaml
+    set:
+      global:
+        env:
+          - name: GLOBAL_ENV
+            value: global-env-value
+      delivery:
+        service2:
+          containers:
+            test:
+              env:
+                - name: GLOBAL_ENV
+                  value: delivery-env-value
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLOBAL_ENV
+            value: delivery-env-value
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLOBAL_ENV
+            value: global-env-value

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -18,6 +18,18 @@
 # -- overwrites tenant for this release installation, defaults to `.Release.Name`
 tenant:
 
+# global settings inherited by all chart components
+global:
+  # -- global environment variables for all containers, can be overridden by component specific env
+  env: []
+
+# -- imagePullSecrets used to authenticate to registry containing StreamX and custom services
+imagePullSecrets: []
+
+monitoring:
+  # -- enabling this flag will enable creating `monitoring.coreos.com` Custom Resources for all services
+  enabled: false
+
 # -- used to configure messaging system like Apache Pulsar, see examples for reference
 messaging: {}
   # -- Apache Pulsar Messaging
@@ -29,18 +41,7 @@ messaging: {}
   #   initTenant: # -- optional: Apache Pulsar tenant and namespaces initialisation for StreamX, this job waits for Apache Pulsar to be ready
   #     enabled: true # -- enable tenant initialisation, this will create a Job to initialise tenant
   #     customImage: # -- optional: custom image for tenant initialisation, by default `streamx-docker-releases/dev.streamx/pulsar-init` with the current chart's AppVersion will be used
-
-# global settings inherited by all services
-global:
-  # -- global environment variables for all services, can be overridden by service specific env
-  env: []
-
-# -- imagePullSecrets used to authenticate to registry containing StreamX and custom services
-imagePullSecrets: []
-
-monitoring:
-  # -- enabling this flag will enable creating `monitoring.coreos.com` Custom Resources for all services
-  enabled: false
+  #     env: [] # -- optional: additional environment variables for tenant initialisation
 
 ## StreamX REST Ingestion Service
 rest_ingestion:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -15,9 +15,6 @@
 # Default values for StreamX
 # This is a YAML-formatted file.
 
-# -- imagePullSecrets used to authenticate to registry containing StreamX and custom services
-imagePullSecrets: []
-
 # -- overwrites tenant for this release installation, defaults to `.Release.Name`
 tenant:
 
@@ -32,6 +29,14 @@ messaging: {}
   #   initTenant: # -- optional: Apache Pulsar tenant and namespaces initialisation for StreamX, this job waits for Apache Pulsar to be ready
   #     enabled: true # -- enable tenant initialisation, this will create a Job to initialise tenant
   #     customImage: # -- optional: custom image for tenant initialisation, by default `streamx-docker-releases/dev.streamx/pulsar-init` with the current chart's AppVersion will be used
+
+# global settings inherited by all services
+global:
+  # -- global environment variables for all services, can be overridden by service specific env
+  env: []
+
+# -- imagePullSecrets used to authenticate to registry containing StreamX and custom services
+imagePullSecrets: []
 
 monitoring:
   # -- enabling this flag will enable creating `monitoring.coreos.com` Custom Resources for all services


### PR DESCRIPTION
## New feature

There is a new global property `env` that enables defining base envs for all chart components (all `containers` and `initContainers`).

It could be useful for defining common variables that are shared among services, like logging settings or common service addres, e.g.:

> `values.yaml`
```yaml
# ...
env:
  - name: QUARKUS_LOG_CATEGORY__DEV_STREAMX__LEVEL
    value: INFO
  - name: QUARKUS_LOG_CATEGORY__ORG_APACHE_PULSAR_CLIENT__LEVEL
    value: INFO
  - name: QUARKUS_LOG_CONSOLE_JSON
    value: "true"
  - name: QUARKUS_LOG_CONSOLE_JSON_KEY_OVERRIDES
    value: "level=severity"
```

Each service's container can overwrite the global envs with its own `env` property (see unit tests for reference).