### PR TITLE
[DXP-610] Rename init tenant job customImage property to image

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ When the `messaging.pulsar.initTenant.enabled` is set to `true`, the chart will 
 
 To customise tenant initialization, you can:
 - set `messaging.pulsar.initTenant.enabled` to `false` and initialize the tenant manually,
-- configure custom `pulsar-init` container image via `messaging.pulsar.initTenant.customImage` value.
+- configure custom `pulsar-init` container image via `messaging.pulsar.initTenant.image` value.
 
 ### Multi-tenant installation
 

--- a/chart/README.md.gotmpl
+++ b/chart/README.md.gotmpl
@@ -97,7 +97,7 @@ When the `messaging.pulsar.initTenant.enabled` is set to `true`, the chart will 
 
 To customise tenant initialization, you can:
 - set `messaging.pulsar.initTenant.enabled` to `false` and initialize the tenant manually,
-- configure custom `pulsar-init` container image via `messaging.pulsar.initTenant.customImage` value.
+- configure custom `pulsar-init` container image via `messaging.pulsar.initTenant.image` value.
 
 ### Multi-tenant installation
 

--- a/chart/templates/messaging/pulsar-init-tenant-job.yaml
+++ b/chart/templates/messaging/pulsar-init-tenant-job.yaml
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       containers:
         - name: pulsar-init
-          image: {{ (.initTenant).customImage | default (printf "ghcr.io/streamx-dev/streamx/pulsar-init:%s" $.Chart.AppVersion) }}
+          image: {{ (.initTenant).image | default (printf "ghcr.io/streamx-dev/streamx/pulsar-init:%s" $.Chart.AppVersion) }}
           env:
             {{- include "streamx.mergeEnvs" (dict "baseEnvs" $.Values.global.env "overwriteEnvs" (.initTenant).env) | nindent 12 }}
             - name: STREAMX_TENANT

--- a/chart/tests/unit/messaging_pulsar_default_image_test.yaml
+++ b/chart/tests/unit/messaging_pulsar_default_image_test.yaml
@@ -1,0 +1,45 @@
+# Copyright 2024 Dynamic Solutions Sp. z o.o. sp.k.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+
+suite: test pulsar initialisation default image
+set:
+  messaging:
+    pulsar:
+      initTenant:
+        enabled: true
+templates:
+  - templates/messaging/pulsar-init-tenant-job.yaml
+
+tests:
+  # @Test
+  - it: verify image set with appVersion by default
+    chart:
+      appVersion: unit.test.version
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/streamx-dev/streamx/pulsar-init:unit.test.version
+  # @Test
+  - it: verify image overwritten when image is set
+    set:
+      messaging:
+        pulsar:
+          initTenant:
+            image: custom-repo/image-name:myVersion
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: custom-repo/image-name:myVersion

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -40,7 +40,7 @@ messaging: {}
   #   webServiceUrl: "http://pulsar-web-service:8080"
   #   initTenant: # -- optional: Apache Pulsar tenant and namespaces initialisation for StreamX, this job waits for Apache Pulsar to be ready
   #     enabled: true # -- enable tenant initialisation, this will create a Job to initialise tenant
-  #     customImage: # -- optional: custom image for tenant initialisation, by default `streamx-docker-releases/dev.streamx/pulsar-init` with the current chart's AppVersion will be used
+  #     image: # -- optional: custom image for tenant initialisation, by default `streamx-docker-releases/dev.streamx/pulsar-init` with the current chart's AppVersion will be used
   #     env: [] # -- optional: additional environment variables for tenant initialisation
 
 ## StreamX REST Ingestion Service


### PR DESCRIPTION
## Upgrade notes
### Breaking change
The `customImage` property of `messaging.pulsar.initTenatn` was renamed to `image` to comply with other image overwrites.

#### Deprecated
```yaml
messaging:
  pulsar:
    initTenant:
      customImage: custom-repo/image-name:myVersion
```
#### Expected
```yaml
messaging:
  pulsar:
    initTenant:
      image: custom-repo/image-name:myVersion
```