### PR TITLE
[DXP-610] added app.kubernetes.io/part-of label with tenant name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.12-jvm](https://img.shields.io/badge/AppVersion-0.0.12--jvm-informational?style=flat-square) 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.12-jvm](https://img.shields.io/badge/AppVersion-0.0.12--jvm-informational?style=flat-square) 
 
 # StreamX Helm Chart
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -17,6 +17,6 @@ name: streamx
 description: This chart bootstraps StreamX on a Kubernetes cluster.
 
 type: application
-version: 0.5.1
+version: 0.6.0
 # Please note that the app version is defined also in the .licenserc.yaml file
 appVersion: 0.0.12-jvm

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -73,6 +73,7 @@ Usage:
 helm.sh/chart: {{ include "streamx.chart" .context }}
 {{ include "streamx.component.selectorLabels" (dict "componentName" .componentName "context" .context) }}
 app.kubernetes.io/managed-by: {{ .context.Release.Service }}
+app.kubernetes.io/part-of: {{ include "streamx.tenant" .context }}
 {{- end }}
 
 {{/*

--- a/chart/tests/unit/delivery_services_labels_test.yaml
+++ b/chart/tests/unit/delivery_services_labels_test.yaml
@@ -33,14 +33,13 @@ tests:
       - templates/delivery/delivery-deployment.yaml
     asserts:
       - isSubset:
-          path: spec.template.metadata
+          path: spec.template.metadata.labels
           content:
-            labels:
-              app.kubernetes.io/component: delivery-webserver
-              app.kubernetes.io/instance: unit-tests
-              app.kubernetes.io/managed-by: Helm
-              app.kubernetes.io/name: streamx
-              helm.sh/chart: streamx-unit.test.version
+            app.kubernetes.io/component: delivery-webserver
+            app.kubernetes.io/instance: unit-tests
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: streamx
+            helm.sh/chart: streamx-unit.test.version
       - contains:
           path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions
           content:

--- a/chart/tests/unit/resources_labels_test.yaml
+++ b/chart/tests/unit/resources_labels_test.yaml
@@ -14,8 +14,12 @@
 
 # yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
 
-suite: test resources names
+suite: test resources labels
+templates:
+  # test all resources created by the chart
+  - templates/[a-z/\-]+/**[a-z/\-]+.yaml
 set:
+  tenant: unit-test-tenant
   monitoring:
     enabled: true
   messaging:
@@ -44,23 +48,22 @@ set:
       containers:
         test:
           image: test/delivery-image
-templates:
-  # test all resources created by the chart
-  - templates/[a-z/\-]+/**[a-z/\-]+.yaml
 tests:
   # @Test
-  - it: deployment name should contain chart name and release name when release name is different than chart name
-    release:
-      name: unit-tests
+  - it: resources should have part-of label that prints the tenant name
     asserts:
-      - matchRegex:
-          path: metadata.name
-          pattern: unit-tests-streamx-.*$
+      - isSubset:
+          path: metadata.labels
+          content:
+            app.kubernetes.io/part-of: unit-test-tenant
   # @Test
-  - it: deployment name should contain release name when release name is the same as chart name
-    release:
-      name: streamx
+  - it: deployment pod templates should have part-of label that prints the tenant name
+    templates:
+      - templates/rest-ingestion-service/rest-ingestion-deployment.yaml
+      - templates/processing/processing-deployment.yaml
+      - templates/delivery/delivery-deployment.yaml
     asserts:
-      - matchRegex:
-          path: metadata.name
-          pattern: streamx-.*$
+      - isSubset:
+          path: spec.template.metadata.labels
+          content:
+            app.kubernetes.io/part-of: unit-test-tenant

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -37,10 +37,10 @@
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | processing._service-name_.env | list | `[]` | additional environment variables for the service |
-| processing._service-name_.image | string | `"_image-repository_:_image-tag_"` | image repository and tag |
+| processing._service-name_.image | string | `"<image-repository>:<image-tag>"` | image repository and tag |
 | processing._service-name_.incoming | object | `{"_incoming-channel-name_":{"namespace":"inboxes","topic":"pages"}}` | map of incoming channels |
 | processing._service-name_.incoming._incoming-channel-name_ | object | `{"namespace":"inboxes","topic":"pages"}` | example incomming channel with defined namespace and topic |
-| processing._service-name_.nodeSelector | object | `{}` | nodeSelector settings (key -_ value) |
+| processing._service-name_.nodeSelector | object | `{}` | nodeSelector settings (key -> value) |
 | processing._service-name_.outgoing | object | `{"_outgoing-channel-name_":{"namespace":"outboxes","topic":"pages"}}` | map of outgoing channels |
 | processing._service-name_.outgoing._outgoing-channel-name_ | object | `{"namespace":"outboxes","topic":"pages"}` | example outgoing channel with defined namespace and topic |
 | processing._service-name_.podMonitor | object | `{"interval":"10s","path":"/q/metrics","scrapeTimeout":"10s"}` | overrides default podMonitor settings |

--- a/examples/jwt-auth/install.sh
+++ b/examples/jwt-auth/install.sh
@@ -20,7 +20,7 @@ set -x -e
 kubectl create namespace secured
 kubectl apply -f examples/jwt-auth/secrets/rest-ingestion-jwt-keys.yaml
 
-# 2. Prepare Apache puslar for StreamX installation
+# 2. Prepare Apache Pulsar for StreamX installation
 helm install secured ./chart -n secured \
   --set messaging.pulsar.initTenant.enabled=true \
   --set rest_ingestion.enabled=false \

--- a/examples/multi-tenant/install.sh
+++ b/examples/multi-tenant/install.sh
@@ -20,7 +20,7 @@ set -x -e
 kubectl create namespace tenant-1
 kubectl create namespace tenant-2
 
-# 2. Prepare Apache puslar for StreamX installation
+# 2. Prepare Apache Pulsar for StreamX installation
 helm install tenant-1 ./chart -n tenant-1 \
   --set messaging.pulsar.initTenant.enabled=true \
   --set rest_ingestion.enabled=false \

--- a/examples/reference/install.sh
+++ b/examples/reference/install.sh
@@ -19,7 +19,7 @@ set -x -e
 # 1. Create namespace
 kubectl create namespace streamx
 
-# 2. Prepare Apache puslar for StreamX installation (run it only for the first time installation)
+# 2. Prepare Apache Pulsar for StreamX installation (run it only for the first time installation)
 helm install reference ./chart -n streamx \
   --set messaging.pulsar.initTenant.enabled=true \
   --set rest_ingestion.enabled=false \


### PR DESCRIPTION
## Motivation and Context
To distinguish tenant for which the application is created for, a new label `app.kubernetes.io/part-of` was introduced.
According to [Helm chart best practices](https://helm.sh/docs/chart_best_practices/labels/#standard-labels):

> `app.kubernetes.io/part-of ` -  should be added when multiple charts or pieces of software are used together to make one application.

Thanks to the label selector queries looking for all components within tenant can be executed.