### PR TITLE
[DXP-610] inboxes, relays and outboxes namespaces topic configured by default with 3 partitions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ to verify StreamX e2e tests for a reference installation. See the corresponding 
 <summary>See how to validate reference flow manually with cURL</summary>
 <p>
 
-Refresh the Ingestion Service schema by calling:
+Browse available schemas in Ingestion Service by calling:
 ```bash
 curl -X 'GET' \
   'http://reference-api.127.0.0.1.nip.io/publications/v1/schema' \

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ The table below documents Messaging configuration options.
 | messaging.pulsar.initTenant.enabled | bool | `false` | enable Apache Pulsar tenant and namespaces initialisation for StreamX, this will create a Job that waits for Apache Pulsar to be ready |
 | messaging.pulsar.initTenant.env | list | `[]` | optional: additional environment variables for tenant initialisation |
 | messaging.pulsar.initTenant.image | string | `"ghcr.io/streamx-dev/streamx/pulsar-init:<appVersion>"` | custom image and tag for tenant initialisation, the default image tag corresponds the current chart's AppVersion |
+| messaging.pulsar.initTenant.partitions.inboxes | int | `3` | optional: number of partitions for inboxes topics, defaults to `3` |
+| messaging.pulsar.initTenant.partitions.outboxes | int | `3` | optional: number of partitions for outboxes topics, defaults to `3` |
+| messaging.pulsar.initTenant.partitions.relays | int | `3` | optional: number of partitions for relays topics, defaults to `3` |
 | messaging.pulsar.serviceUrl | string | `nil` | mandatory: Apache Pulsar Broker Service URL, e.g. `"pulsar://pulsar-service:6650"` |
 | messaging.pulsar.webServiceUrl | string | `nil` | mandatory: Apache Pulsar REST API URL, e.g. `"http://pulsar-web-service:8080"` |
 <!-- end: messaging.md -->

--- a/chart/docs/messaging.yaml
+++ b/chart/docs/messaging.yaml
@@ -23,5 +23,12 @@ messaging:
       enabled: false
       # -- custom image and tag for tenant initialisation, the default image tag corresponds the current chart's AppVersion
       image: ghcr.io/streamx-dev/streamx/pulsar-init:<appVersion>
+      partitions:
+        # -- optional: number of partitions for inboxes topics, defaults to `3`
+        inboxes: 3
+        # -- optional: number of partitions for relays topics, defaults to `3`
+        relays: 3
+        # -- optional: number of partitions for outboxes topics, defaults to `3`
+        outboxes: 3
       # -- optional: additional environment variables for tenant initialisation
       env: []

--- a/chart/templates/messaging/pulsar-init-tenant-job.yaml
+++ b/chart/templates/messaging/pulsar-init-tenant-job.yaml
@@ -35,6 +35,12 @@ spec:
             {{- include "streamx.mergeEnvs" (dict "baseEnvs" $.Values.global.env "overwriteEnvs" (.initTenant).env) | nindent 12 }}
             - name: STREAMX_TENANT
               value: {{ include "streamx.tenant" $ }}
+            - name: STREAMX_INBOXES_PARTITIONS
+              value: {{ (.initTenant.partitions).inboxes | default "3" | quote }}
+            - name: STREAMX_RELAYS_PARTITIONS
+              value: {{ (.initTenant.partitions).relays | default "3" | quote }}
+            - name: STREAMX_OUTBOXES_PARTITIONS
+              value: {{ (.initTenant.partitions).outboxes | default "3" | quote }}
             {{- include "streamx.pulsarEnvs" $ | nindent 12 }}
       restartPolicy: OnFailure
       initContainers:

--- a/chart/tests/unit/messaging_pulsar_init_test.yaml
+++ b/chart/tests/unit/messaging_pulsar_init_test.yaml
@@ -100,3 +100,55 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: ghcr.io/streamx-dev/streamx/pulsar-init:unit.test.version
+  # @Test
+  - it: by default init tenant job will configure 3 partitions for inboxes, relays and outboxes
+    set:
+      messaging:
+        pulsar:
+          initTenant:
+            enabled: true
+    template: templates/messaging/pulsar-init-tenant-job.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STREAMX_INBOXES_PARTITIONS
+            value: "3"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STREAMX_RELAYS_PARTITIONS
+            value: "3"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STREAMX_OUTBOXES_PARTITIONS
+            value: "3"
+  # @Test
+  - it: when partitions are set then init tenant job will configure them
+    set:
+      messaging:
+        pulsar:
+          initTenant:
+            enabled: true
+            partitions:
+              inboxes: 6
+              relays: 6
+              outboxes: 6
+    template: templates/messaging/pulsar-init-tenant-job.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STREAMX_INBOXES_PARTITIONS
+            value: "6"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STREAMX_RELAYS_PARTITIONS
+            value: "6"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STREAMX_OUTBOXES_PARTITIONS
+            value: "6"

--- a/tests/e2e/src/test/java/dev/streamx/chart/validation/MultiTenantPublicationTest.java
+++ b/tests/e2e/src/test/java/dev/streamx/chart/validation/MultiTenantPublicationTest.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import dev.streamx.clients.ingestion.exceptions.StreamxClientException;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,8 +35,6 @@ public class MultiTenantPublicationTest {
   private final StreamXEnvironment tenant2 = StreamXEnvironment.newLocalEnvironment("tenant-2");
 
   @Test
-  // FixMe order should not matter after schema autoupdate implemented in StreamX
-  @Order(1)
   void restIngestionShouldHavePagesSchemaConfigured()
       throws JsonProcessingException {
     EnvironmentAssertions.assertPagesJsonSchema(tenant1.newIngestionSchemaRequest());
@@ -45,7 +42,6 @@ public class MultiTenantPublicationTest {
   }
 
   @Test
-  @Order(2)
   @DisplayName("Check page published on first tenant is not visible on second tenant")
   public void checkTenantsPublicationSeparation()
       throws StreamxClientException {

--- a/tests/e2e/src/test/java/dev/streamx/chart/validation/ReferencePublicationTest.java
+++ b/tests/e2e/src/test/java/dev/streamx/chart/validation/ReferencePublicationTest.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import dev.streamx.clients.ingestion.exceptions.StreamxClientException;
 import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,16 +33,40 @@ public class ReferencePublicationTest {
 
   static final String REFERENCE_PAGE_CONTENT = "<h1>Unit tests for reference StreamX flow</h1>";
 
+  private static final String STRICT_SCHEMA = """
+    {
+       "pages": {
+         "type":"record",
+         "name":"Page",
+         "namespace":"dev.streamx.reference.relay.model",
+         "fields":[
+           {
+             "name":"content",
+             "type":[
+               "null",
+               "bytes"
+             ],
+             "default":null
+           }
+         ]
+       }
+     }
+     """;
+
   @Test
-  // FixMe order should not matter after schema autoupdate implemented in StreamX
-  @Order(1)
   void restIngestionShouldHavePagesSchemaConfigured(StreamXEnvironment environment)
       throws JsonProcessingException {
     EnvironmentAssertions.assertPagesJsonSchema(environment.newIngestionSchemaRequest());
   }
 
   @Test
-  @Order(2)
+  @Disabled("Enable after fixing DXP-695")
+  void restIngestionShouldHaveStrictValue(StreamXEnvironment environment)
+      throws JsonProcessingException {
+    EnvironmentAssertions.assertStrictJsonSchema(environment.newIngestionSchemaRequest(), STRICT_SCHEMA);
+  }
+
+  @Test
   void publishedPageShouldBeAvailableOnWebDeliveryService(StreamXEnvironment environment)
       throws StreamxClientException {
     String key = "test-" + UUID.randomUUID() + ".html";

--- a/tests/e2e/src/test/java/dev/streamx/chart/validation/SecuredPublicationTest.java
+++ b/tests/e2e/src/test/java/dev/streamx/chart/validation/SecuredPublicationTest.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import dev.streamx.clients.ingestion.exceptions.StreamxClientException;
 import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,15 +34,12 @@ public class SecuredPublicationTest {
   static final String SECURED_PAGE_CONTENT = "<h1>Unit tests for secured StreamX flow</h1>";
 
   @Test
-  // FixMe order should not matter after schema autoupdate implemented in StreamX
-  @Order(1)
   void restIngestionShouldHavePagesSchemaConfigured(SecuredStreamXEnvironment environment)
       throws JsonProcessingException {
     EnvironmentAssertions.assertPagesJsonSchema(environment.newIngestionSchemaRequest());
   }
 
   @Test
-  @Order(2)
   void publishedPageShouldBeAvailableOnWebDeliveryService(SecuredStreamXEnvironment environment)
       throws StreamxClientException {
     String key = "test-" + UUID.randomUUID() + ".html";


### PR DESCRIPTION
## Motivation and Context
Enables configuring default number of partitions for topics created in `inboxes`, `relays` and `outboxes` namespaces.
By default chart will configure each namespace to create topics with `3` partitions.

## Upgrade notes

#### Before
Remove `env` settings from `messaging.pulsar.initTenant.env` for partitions:
```
messaging:
  pulsar:
    initTenant:
      env:
        - name: STREAMX_INBOXES_PARTITIONS
          value: "6"
        - name: STREAMX_RELAYS_PARTITIONS
          value: "6"
        - name: STREAMX_OUTBOXES_PARTITIONS
          value: "6"
```
#### After
Use chart's settings instead:
```
messaging:
  pulsar:
    initTenant: 
      partitions:
        inboxes: 6
        relays: 6
        outboxes: 6
```

