### PR TITLE
[DXP-655] add enabled flag for rest ingestion ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,10 @@ The table below documents REST Ingestion Service configuration options.
 | rest_ingestion.image | string | `"ghcr.io/streamx-dev/streamx/rest-ingestion-service:<appVersion>"` | custom image and tag for tenant initialisation, the default image tag corresponds the current chart's AppVersion |
 | rest_ingestion.imagePullPolicy | string | `nil` | image pull policy |
 | rest_ingestion.ingress.annotations | object | `{}` | additional ingress annotations |
-| rest_ingestion.ingress.host | string | `nil` | host for the ingress, set the value to enable ingress, empty by default |
+| rest_ingestion.ingress.enabled | bool | `false` | enables ingress |
+| rest_ingestion.ingress.host | string | `nil` | host for the ingress and TLS certificate |
 | rest_ingestion.ingress.ingressClassName | string | `"nginx"` | ingress class name |
-| rest_ingestion.ingress.tls.secretName | string | `nil` | secret name for the TLS certificate, set the value to enable TLS |
+| rest_ingestion.ingress.tls.secretName | string | `nil` | secret name for the TLS certificate, set the value and `host` to enable TLS |
 | rest_ingestion.monitoring | object | `{}` | pod monitoring configuration |
 | rest_ingestion.nodeSelector | object | `{}` | node labels for pod assignment |
 | rest_ingestion.probes | object | `{}` | probes settings, see tests for reference |

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The table below documents REST Ingestion Service configuration options.
 | rest_ingestion.ingress.enabled | bool | `false` | enables ingress |
 | rest_ingestion.ingress.host | string | `nil` | host for the ingress and TLS certificate |
 | rest_ingestion.ingress.ingressClassName | string | `"nginx"` | ingress class name |
-| rest_ingestion.ingress.tls.secretName | string | `nil` | secret name for the TLS certificate, set the value and `host` to enable TLS |
+| rest_ingestion.ingress.tls.secretName | string | `nil` | secret name for the TLS certificate, set the value and `host` to enable TLS, secret must be created in the same namespace as the Ingestion Service |
 | rest_ingestion.monitoring | object | `{}` | pod monitoring configuration |
 | rest_ingestion.nodeSelector | object | `{}` | node labels for pod assignment |
 | rest_ingestion.probes | object | `{}` | probes settings, see tests for reference |
@@ -177,11 +177,12 @@ Each Delivery Service can consist of multiple containers. Refer to the `Example`
 | delivery._service-name_.incoming | object | `{"_incoming-channel-name_":{"namespace":"outboxes","topic":"pages"}}` | map of incoming channels |
 | delivery._service-name_.incoming._incoming-channel-name_ | object | `{"namespace":"outboxes","topic":"pages"}` | example incomming channel with defined namespace and topic |
 | delivery._service-name_.nodeSelector | object | `{}` | nodeSelector settings (key -> value) |
-| delivery._service-name_.outputs | object | `{"_output-name_":{"ingress":{"annotations":{},"host":"my-domain.com","path":"/my-path","tls":{"secretName":"tls-secret"}},"service":{"containerRef":{"name":"_container-name_"},"port":80,"targetPort":"http"}}}` | map of delivery outputs |
 | delivery._service-name_.outputs._output-name_.ingress.annotations | object | `{}` | additional annotations for ingress |
-| delivery._service-name_.outputs._output-name_.ingress.host | string | `"my-domain.com"` | optional, set `host` to enable ingress |
+| delivery._service-name_.outputs._output-name_.ingress.enabled | bool | `false` | enables ingress, disabled by default |
+| delivery._service-name_.outputs._output-name_.ingress.host | string | `"my-domain.com"` | host for the ingress and TLS certificate |
+| delivery._service-name_.outputs._output-name_.ingress.ingressClassName | string | `"nginx"` | ingress class name, defaults to `nginx` |
 | delivery._service-name_.outputs._output-name_.ingress.path | string | `"/my-path"` | optional, defaults to "/" |
-| delivery._service-name_.outputs._output-name_.ingress.tls.secretName | string | `"tls-secret"` | optional, set to enable TLS, secret must be created in the same namespace |
+| delivery._service-name_.outputs._output-name_.ingress.tls.secretName | string | `"tls-secret"` | secret name for the TLS certificate, set the value and `host` to enable TLS, secret must be created in the same namespace as the Delivery Service |
 | delivery._service-name_.outputs._output-name_.service.containerRef.name | string | `"_container-name_"` | corresponds to container name in `containers` section |
 | delivery._service-name_.outputs._output-name_.service.port | int | `80` | port on which Kubernetes service is listening for traffic for this Delivery Service |
 | delivery._service-name_.outputs._output-name_.service.targetPort | string | `"http"` | name of the port in the container |

--- a/chart/docs/delivery.yaml
+++ b/chart/docs/delivery.yaml
@@ -22,7 +22,6 @@ delivery:
       _incoming-channel-name_:
         namespace: outboxes
         topic: pages
-    # -- map of delivery outputs
     outputs:
       _output-name_:
         service:
@@ -34,15 +33,19 @@ delivery:
           # -- name of the port in the container
           targetPort: http
         ingress:
-          # -- optional, set `host` to enable ingress
+          # -- enables ingress, disabled by default
+          enabled: false
+          # -- host for the ingress and TLS certificate
           host: my-domain.com
           # -- optional, defaults to "/"
           path: /my-path
           # -- additional annotations for ingress
           annotations: {}
           tls:
-            # -- optional, set to enable TLS, secret must be created in the same namespace
+            # -- secret name for the TLS certificate, set the value and `host` to enable TLS, secret must be created in the same namespace as the Delivery Service
             secretName: tls-secret
+          # -- ingress class name, defaults to `nginx`
+          ingressClassName: nginx
     containers:
       _container-name_:
         # -- image repository and tag

--- a/chart/docs/ingestion.yaml
+++ b/chart/docs/ingestion.yaml
@@ -31,12 +31,14 @@ rest_ingestion:
   # -- image pull policy
   imagePullPolicy:
   ingress:
+    # -- enables ingress
+    enabled: false
     # -- additional ingress annotations
     annotations: {}
-    # -- (string) host for the ingress, set the value to enable ingress, empty by default
+    # -- (string) host for the ingress and TLS certificate
     host: 
     tls:
-      # -- (string) secret name for the TLS certificate, set the value to enable TLS
+      # -- (string) secret name for the TLS certificate, set the value and `host` to enable TLS
       secretName:
     # -- ingress class name
     ingressClassName: nginx

--- a/chart/docs/ingestion.yaml
+++ b/chart/docs/ingestion.yaml
@@ -38,7 +38,7 @@ rest_ingestion:
     # -- (string) host for the ingress and TLS certificate
     host: 
     tls:
-      # -- (string) secret name for the TLS certificate, set the value and `host` to enable TLS
+      # -- (string) secret name for the TLS certificate, set the value and `host` to enable TLS, secret must be created in the same namespace as the Ingestion Service
       secretName:
     # -- ingress class name
     ingressClassName: nginx

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -26,9 +26,11 @@ Deploy StreamX Mesh when the initialization completes successfully.
 {{- end }}
 {{- end }}
 
-{{- with (.Values.rest_ingestion).ingress }}
+{{- with .Values.rest_ingestion.ingress }}
+{{- if .enabled }}
 Ingestion services:
 - http{{ if (.tls).secretName }}s{{ end }}://{{ .host }}
+{{- end }}
 {{- end }}
 
 {{- if gt (len .Values.delivery) 0 }}

--- a/chart/templates/delivery/delivery-ingress.yaml
+++ b/chart/templates/delivery/delivery-ingress.yaml
@@ -15,6 +15,7 @@
 {{- range $name, $delivery := .Values.delivery }}
 {{- range $outputName, $output := $delivery.outputs }}
 {{ with $output.ingress }}
+{{- if .enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -30,11 +31,16 @@ spec:
   {{- if (.tls).secretName }}
   tls:
     - hosts:
+        {{- if .host }}
         - {{ .host | quote }}
+        {{- end }}
       secretName: {{ .tls.secretName }}
   {{- end }}
   rules:
-  - host: {{ .host | quote }}
+  - 
+    {{- if .host }}
+    host: {{ .host | quote }}
+    {{- end }}
     http:
       paths:
       - pathType: Prefix
@@ -45,6 +51,7 @@ spec:
             port:
               number: {{ $output.service.port }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/chart/templates/rest-ingestion-service/rest-ingestion-ingress.yaml
+++ b/chart/templates/rest-ingestion-service/rest-ingestion-ingress.yaml
@@ -14,6 +14,7 @@
 
 {{- if .Values.rest_ingestion.enabled }}
 {{ with .Values.rest_ingestion.ingress  }}
+{{- if .enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -29,11 +30,16 @@ spec:
   {{- if (.tls).secretName }}
   tls:
     - hosts:
-        - {{ .host }}
+        {{- if .host }}
+        - {{ .host | quote }}
+        {{- end }}
       secretName: {{ .tls.secretName }}
   {{- end }}
   rules:
-  - host: {{ .host | quote }}
+  - 
+    {{- if .host }}
+    host: {{ .host | quote }}
+    {{- end }}
     http:
       paths:
       - pathType: Prefix
@@ -43,5 +49,6 @@ spec:
             name: {{ include "streamx.component.fullname" (dict "componentName" "rest-ingestion" "context" $) }}
             port:
               number: 80
+{{- end }}
 {{- end }}
 {{- end }}

--- a/chart/tests/unit/delivery_services_outputs_test.yaml
+++ b/chart/tests/unit/delivery_services_outputs_test.yaml
@@ -84,7 +84,7 @@ tests:
           path: spec.ports[1].targetPort
           value: https
   # @Test
-  - it: when a single output defined and ingress host configured a single ingress is created with default path
+  - it: when a single output defined and ingress enabled a single ingress is created with default path
     template: templates/delivery/delivery-ingress.yaml
     set:
       delivery:
@@ -95,7 +95,7 @@ tests:
                 port: 80
                 targetPort: http
               ingress:
-                host: unit.test.host
+                enabled: true
     asserts:
       - isKind: 
           of: Ingress
@@ -104,9 +104,6 @@ tests:
       - matchRegex:
           path: .metadata.name
           pattern: -delivery-service1-output1$
-      - equal:
-          path: spec.rules[0].host
-          value: unit.test.host
       - equal:
           path: spec.rules[0].http.paths[0].path
           value: /
@@ -117,7 +114,7 @@ tests:
           path: spec.rules[0].http.paths[0].backend.service.port.number
           value: 80
   # @Test
-  - it: when multiple outputs defined with ingress hosts then multiple ingresses are created
+  - it: when multiple outputs defined with ingresses enabled then multiple ingresses are created
     template: templates/delivery/delivery-ingress.yaml
     set:
       delivery:
@@ -128,12 +125,14 @@ tests:
                 port: 80
                 targetPort: http
               ingress:
+                enabled: true
                 host: unit.test.host1
             output2:
               service:
                 port: 443
                 targetPort: https
               ingress:
+                enabled: true
                 host: unit.test.host2
     asserts:
       - isKind: 
@@ -147,7 +146,7 @@ tests:
           path: spec.rules
           count: 1
   # @Test
-  - it: when multiple outputs defined ingress is created only when host defined
+  - it: when multiple outputs defined ingress is created only when enabled
     template: templates/delivery/delivery-ingress.yaml
     set:
       delivery:
@@ -158,7 +157,7 @@ tests:
                 port: 80
                 targetPort: http
               ingress:
-                host: unit.test.host1
+                enabled: true
             output2:
               service:
                 port: 443
@@ -169,7 +168,7 @@ tests:
       - hasDocuments:
           count: 1
   # @Test
-  - it: when ingress tls secret is set then ingress should be created with tls settings
+  - it: when ingress enabled and tls secret is set then ingress should be created with tls settings
     template: templates/delivery/delivery-ingress.yaml
     set:
       delivery:
@@ -180,6 +179,7 @@ tests:
                 port: 80
                 targetPort: http
               ingress:
+                enabled: true
                 host: unit.test.host
                 tls:
                   secretName: tls-secret-test

--- a/chart/tests/unit/notes_test.yaml
+++ b/chart/tests/unit/notes_test.yaml
@@ -23,6 +23,7 @@ tests:
     set:
       rest_ingestion:
         ingress:
+          enabled: true
           host: rest.ingestion.host
     asserts:
       - matchSnapshot: {}
@@ -33,6 +34,7 @@ tests:
     set:
       rest_ingestion:
         ingress:
+          enabled: true
           host: rest.ingestion.host
           tls:
             secretName: tls-secret

--- a/chart/tests/unit/resources_labels_test.yaml
+++ b/chart/tests/unit/resources_labels_test.yaml
@@ -44,7 +44,7 @@ set:
             port: 80
             targetPort: http
           ingress:
-            host: unit.test.host
+            enabled: true
       containers:
         test:
           image: test/delivery-image

--- a/chart/tests/unit/resources_labels_test.yaml
+++ b/chart/tests/unit/resources_labels_test.yaml
@@ -28,7 +28,7 @@ set:
         enabled: true
   rest_ingestion:
     ingress:
-      host: unit.test.host
+      enabled: true
     monitoring:
       path: /metrics
   processing:

--- a/chart/tests/unit/resources_names_test.yaml
+++ b/chart/tests/unit/resources_names_test.yaml
@@ -24,7 +24,7 @@ set:
         enabled: true
   rest_ingestion:
     ingress:
-      host: unit.test.host
+      enabled: true
     monitoring:
       path: /metrics
   processing:

--- a/chart/tests/unit/resources_names_test.yaml
+++ b/chart/tests/unit/resources_names_test.yaml
@@ -40,7 +40,7 @@ set:
             port: 80
             targetPort: http
           ingress:
-            host: unit.test.host
+            enabled: true
       containers:
         test:
           image: test/delivery-image

--- a/chart/tests/unit/rest_ingestion_service_ingress_test.yaml
+++ b/chart/tests/unit/rest_ingestion_service_ingress_test.yaml
@@ -19,32 +19,30 @@ templates:
   - templates/rest-ingestion-service/rest-ingestion-ingress.yaml
 tests:
   # @Test
-  - it: when ingress host not set then ingress should not be created
+  - it: when ingress is not enabled then ingress should not be created
     asserts:
       - hasDocuments:
           count: 0
   # @Test
-  - it: when ingress host is set then ingress should be created and allow only "/publications" path
+  - it: when ingress enabled then ingress should be created and allow only "/publications" path
     set:
       rest_ingestion:
         ingress:
-          host: unit.test.host
+          enabled: true
     asserts:
       - hasDocuments:
           count: 1
       - isKind: 
           of: Ingress
       - matchRegex:
-          path: spec.rules[0].host
-          pattern: unit.test.host
-      - matchRegex:
           path: spec.rules[0].http.paths[0].path
           pattern: /publications
   # @Test
-  - it: when ingress tls secret is set then ingress should be created with tls settings
+  - it: when ingress enabled and tls secret is set then ingress should be created with tls settings
     set:
       rest_ingestion:
         ingress:
+          enabled: true
           host: unit.test.host
           tls:
             secretName: tls-secret-test
@@ -67,7 +65,7 @@ tests:
     set:
       rest_ingestion:
         ingress:
-          host: unit.test.host
+          enabled: true
     asserts:
       - hasDocuments:
           count: 1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -39,7 +39,9 @@ rest_ingestion:
   replicas: 1
   # @ignored in generated docs
   allInboxesTopicPatter: "inboxes/.*"
-
+  # @ignored in generated docs
+  ingress:
+    enabled: false
 
 # -- `Processing Services` map, see the [Processing Services](#processing-services) section for reference
 processing: {}

--- a/examples/jwt-auth/delivery.yaml
+++ b/examples/jwt-auth/delivery.yaml
@@ -27,6 +27,7 @@ delivery:
           port: 80
           targetPort: http
         ingress:
+          enabled: true
           host: secured.127.0.0.1.nip.io
     containers:
       webserver:

--- a/examples/jwt-auth/ingestion.yaml
+++ b/examples/jwt-auth/ingestion.yaml
@@ -17,4 +17,5 @@ rest_ingestion:
   auth:
     keysSecretName: streamx-api-keys
   ingress:
+    enabled: true
     host: secured-api.127.0.0.1.nip.io

--- a/examples/multi-tenant/tenant-1/delivery.yaml
+++ b/examples/multi-tenant/tenant-1/delivery.yaml
@@ -27,6 +27,7 @@ delivery:
           port: 80
           targetPort: http
         ingress:
+          enabled: true
           host: tenant-1.127.0.0.1.nip.io
     containers:
       webserver:

--- a/examples/multi-tenant/tenant-1/ingestion.yaml
+++ b/examples/multi-tenant/tenant-1/ingestion.yaml
@@ -15,4 +15,5 @@
 rest_ingestion:
   allInboxesTopicPatter: "inboxes/.*"
   ingress:
+    enabled: true
     host: tenant-1-api.127.0.0.1.nip.io

--- a/examples/multi-tenant/tenant-2/delivery.yaml
+++ b/examples/multi-tenant/tenant-2/delivery.yaml
@@ -27,6 +27,7 @@ delivery:
           port: 80
           targetPort: http
         ingress:
+          enabled: true
           host: tenant-2.127.0.0.1.nip.io
     containers:
       webserver:

--- a/examples/multi-tenant/tenant-2/ingestion.yaml
+++ b/examples/multi-tenant/tenant-2/ingestion.yaml
@@ -15,4 +15,5 @@
 rest_ingestion:
   allInboxesTopicPatter: "inboxes/.*"
   ingress:
+    enabled: true
     host: tenant-2-api.127.0.0.1.nip.io

--- a/examples/reference/delivery.yaml
+++ b/examples/reference/delivery.yaml
@@ -27,6 +27,7 @@ delivery:
           port: 80
           targetPort: http
         ingress:
+          enabled: true
           host: reference.127.0.0.1.nip.io
     containers:
       webserver:

--- a/examples/reference/ingestion.yaml
+++ b/examples/reference/ingestion.yaml
@@ -16,4 +16,5 @@ rest_ingestion:
   replicas: 2
   allInboxesTopicPatter: "inboxes/.*"
   ingress:
+    enabled: true
     host: reference-api.127.0.0.1.nip.io


### PR DESCRIPTION
## Motivation and Context
StreamX services ingresses should be enabled by a dedicated `enabled` flag which is a standard approach in Helm charts.

## Upgrade notes
REST Ingestion and all Delivery Services ingresses are now disabled by default. Add `enabled: true` flag to enable them.

### Breaking change

#### REST Ingestion

_Before_
```yaml
rest_ingestion:
  ingress:
    host: example.com # setting host enabled ingress
```

_After_
```yaml
rest_ingestion:
  ingress:
    enabled: true # enabling this flag is required to create ingress for the REST Ingestion Service
    host: example.com
```

#### Delivery Services

_Before_
```yaml
delivery:
  reference-service:
    outputs:
      http:
        ingress:
          host: reference.127.0.0.1.nip.io # setting host enabled ingress
```

_After_
```yaml
delivery:
  reference-service:
    outputs:
      http:
        ingress:
          enabled: true # enabling this flag is required to create ingress for the Reference Delivery Service output
          host: reference.127.0.0.1.nip.io
```
